### PR TITLE
Remove "engines"-section from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "https://github.com/mausworks/maus-to"
   },
-  "engines": {
-    "node": "> 12.x"
-  },
   "dependencies": {
     "@vercel/node": "^1.8.4",
     "ajv": "^6.12.6",


### PR DESCRIPTION
[Vercel states: "12.x (The default if the property is not defined)"](https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-version)