### PR TITLE
Clear form only on successful submit

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -10,11 +10,17 @@
 
   let links = userLinks.list();
   let error = "";
+  let slug = "";
+  let url = "";
 
-  function submitLink(submission) {
+  function onSubmitted(submission) {
     postSubmission(submission)
       .then((link) => {
         links = userLinks.add(link);
+
+        // Seems it's only possible to clear using "null"
+        url = null;
+        slug = null;
       })
       .catch(({ message }) => {
         error = message;
@@ -38,7 +44,7 @@
 
 <Card>
   <h1>Shorten link</h1>
-  <ShortenerForm onSubmitted={submitLink} {error} />
+  <ShortenerForm {onSubmitted} {url} {slug} {error} />
 </Card>
 
 {#if links && links.length}

--- a/src/ShortenerForm.svelte
+++ b/src/ShortenerForm.svelte
@@ -4,8 +4,8 @@
   export let error = "";
   export let onSubmitted = () => {};
 
-  let url = "";
-  let slug = "";
+  export let url = "";
+  export let slug = "";
 
   function submitForm(event) {
     event.preventDefault();
@@ -16,8 +16,6 @@
       url,
       slug: trimmedSlug ? trimmedSlug : undefined,
     });
-
-    url = "";
 
     return false;
   }


### PR DESCRIPTION
Currently the URL gets cleared when submitting (not the slug), and it does so before the form data is sent.

This fixes that.